### PR TITLE
Add migrate Command for PHI DB Migrations with Optional Service Argument

### DIFF
--- a/commands/phi-db.py
+++ b/commands/phi-db.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+from ldo.main import BaseCommand
+from ldo.utils import run_command
+from ldo.constants import DOCKER_COMPOSE_DIR
+
+class PHIDBCommand(BaseCommand):
+    def register(self, subparser: argparse.ArgumentParser) -> None:
+        """Register the core command and its subcommands."""
+        action_subparsers = subparser.add_subparsers(dest="action", required=True)
+
+        action_parser = action_subparsers.add_parser(
+            "migrate",
+            help="Run migrations to PHI DB"
+        )
+        action_parser.add_argument(
+          "service",  choices=["form", "patient"], nargs="?", help="Service names using PHI DB"
+        )
+
+
+    def run(self, args: argparse.Namespace) -> None:
+        """Run the appropriate core action based on the parsed arguments."""
+        if args.action == "migrate":
+          if args.service[0] is None:
+            print(f"Unknown or empty service. Migration will run for both services.")
+          
+          self.client_migrate(args.service[0])
+        else:
+            print(f"Unknown action: {args.action}")
+
+    def migrate(self, service) -> None:
+        os.chdir(DOCKER_COMPOSE_DIR)
+
+        if service == "form":
+          docker_command = "docker-compose exec -T phidb bash -c 'yarn form:migrate'"
+        elif service == "patient":
+          docker_command = "docker-compose exec -T phidb bash -c 'yarn patient:migrate'"
+        else:
+          docker_command = "docker-compose exec -T phidb bash -c 'yarn form:migrate && yarn patient:migrate'"
+
+        run_command(docker_command)


### PR DESCRIPTION
## **Description:**

This PR introduces a new `migrate` command for the PHI DB that allows users to perform migrations either for specific services (`form` or `patient`) or for both services if no service is specified. The changes enhance the flexibility of database migrations by enabling different execution modes based on the command-line input.

## **Key Changes:**

1. **Command Registration:**
   - A new `migrate` subcommand is added, with an optional `service` argument that can be either `"form"`, `"patient"`, or omitted.
   - When no service is specified, migrations for both `form` and `patient` will be run.

2. **Argument Handling:**
   - The `service` argument is optional (`nargs="?"`). If no service is provided, both `form` and `patient` migrations will run.
   - If a specific service is provided (either `"form"` or `"patient"`), the migration for that service will be executed.

3. **Execution Logic:**
   - The `client_migrate` method runs the appropriate Docker command to trigger the necessary migration script inside the `phidb` Docker container.
   - If no service is provided, it runs both `yarn form:migrate` and `yarn patient:migrate`.
   - Otherwise, it runs the corresponding migration for the provided service.

4. **Error Handling:**
   - In the case of an invalid or empty service, the default behavior is to run migrations for both services.

## **CLI Usage Examples:**

- Run migrations for the `form` service:
  ```bash
  ./ldo phi-db migrate form
  ```

- Run migrations for the `patient` service:
  ```bash
  ./ldo phi-db migrate patient
  ```

- Run migrations for both `form` and `patient` services:
  ```bash
  ./ldo phi-db migrate
  ```
