### PR TITLE
Use only sync command for db

### DIFF
--- a/commands/db.py
+++ b/commands/db.py
@@ -25,5 +25,5 @@ class DBCommand(BaseCommand):
 
     def client_migrate(self) -> None:
         os.chdir(DOCKER_COMPOSE_DIR)
-        docker_command = "docker-compose exec -T db bash -c 'yarn client:migrate && yarn client:sync'"
+        docker_command = "docker-compose exec -T db bash -c 'yarn client:sync'"
         run_command(docker_command)


### PR DESCRIPTION
## Changes

- Use only `yarn synchronize` as it does both migration and view/function sync with single command
- Job of `yarn client:migrate` is done by above itself so its redundant

